### PR TITLE
Added option to use entity icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Button card
 
-Lovelace Button card for your entities. 
+Lovelace Button card for your entities.
 
 ![all](examples/all.gif)
 
@@ -28,7 +28,7 @@ Lovelace Button card for your entities.
 | ---- | ---- | ------- | --------- | -----------
 | type | string | **Required** | `custom:button-card` | Type of the card
 | entity | string | **Required** | `switch.ac` | entity_id
-| icon | string | optional | `mdi:air-conditioner` | Icon to display in place of the state
+| icon | string | optional | `mdi:air-conditioner` \| `attribute` | Icon to display in place of the state. If you use attribute it will fetch the icon configured on the entity.
 | color_type | string | `icon` | `icon` \| `card` \| `blank-card` | Color either the background of the card or the icon inside the card. Setting this to `card` enable automatic `font` and `icon` color. This allows the text/icon to be readable even if the background color is bright/dark.
 | color | string | `var(--primary-text-color)` | `auto` \| `rgb(28, 128, 199)` |  Color of the icon/card when state is `on`. `auto` sets the color based on the color of a light.
 | color_off | string | `var(--disabled-text-color)` | `rgb(28, 128, 199)` |  Color of the icon/card when state is `off`.
@@ -58,7 +58,7 @@ To configure custom_updater with button-card
 
 ```
 custom_updater:
-  card_urls: 
+  card_urls:
     - https://raw.githubusercontent.com/kuuji/button-card/0.0.2/tracker.json
 ```
 

--- a/button-card.js
+++ b/button-card.js
@@ -51,6 +51,18 @@ class ButtonCard extends LitElement {
     return colorOn;
   }
 
+  buildIcon(state, config) {
+    let iconOff = config.icon;
+    if (config.icon == 'attribute') {
+      if (state) {
+        const icon = state.attributes.icon;
+        return icon;
+      }
+      return iconOff;
+    }
+    return iconOff;
+  }
+
   blankCardColoredHtml(state, config) {
     const color = this.buildCssColorAttribute(state, config);
     const fontColor = this.getFontColorBasedOnBackgroundColor(color);
@@ -65,7 +77,7 @@ class ButtonCard extends LitElement {
     const fontColor = this.getFontColorBasedOnBackgroundColor(color);
     return html`
     <style>
-    ha-icon {  
+    ha-icon {
       display: flex;
       margin: auto;
     }
@@ -89,9 +101,10 @@ class ButtonCard extends LitElement {
 
   iconColoredHtml(state, config) {
     const color = this.buildCssColorAttribute(state, config);
+    const icon = this.buildIcon(state, config);
     return html`
     <style>
-    ha-icon {  
+    ha-icon {
       display: flex;
       margin: auto;
     }
@@ -104,7 +117,7 @@ class ButtonCard extends LitElement {
     <ha-card on-tap="${ev => this._toggle(state, config)}">
       <paper-button style="${config.card_style}">
       <div>
-        ${config.icon ? html`<ha-icon style="color: ${color}; width: ${config.size}; height: ${config.size};" icon="${config.icon}"></ha-icon>` : ''}
+        ${config.icon ? html`<ha-icon style="color: ${color}; width: ${config.size}; height: ${config.size};" icon="${icon}"></ha-icon>` : ''}
         ${config.name ? html`<span>${config.name}</span>` : ''}
         ${config.show_state ? html`<span>${state.state}</span>` : ''}
       </div>


### PR DESCRIPTION
I wanted to have an option to defined different icons based on state but then I realized that sometimes the entity already contains the icon information as an attribute. 
If you already customized the entity with your own icon it can fetch that attribute directly from the entity instead of defining it again.
In my scenario I wanted to show different icons based on my template cover state. The template cover already have a state_open and state_close icon.

So if you add `icon: attribute` it will look for the "icon" attribute in the entity.

I´m not familiar with javascript so the code might not be optimal but it´s working. Feel free to adjust if there is a better way.